### PR TITLE
Abmelde-Modul Änderung

### DIFF
--- a/modules/abmeldung-out.inc.php
+++ b/modules/abmeldung-out.inc.php
@@ -1,6 +1,7 @@
 <?php
 // Abmeldung aus Formular holen
 $unsubscribe_mail = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+$unsubscribe_button = rex_request('unsubscribe_newsletter',"",0);
 if($unsubscribe_mail == "") {
 	// Abmeldung aus URL holen
 	$unsubscribe_mail = filter_input(INPUT_GET, 'unsubscribe', FILTER_VALIDATE_EMAIL);
@@ -17,7 +18,7 @@ else {
 	print '<br>';
 	
 	$showform = true;
-	if($unsubscribe_mail != "") {
+	if($unsubscribe_mail != "" && $unsubscribe_button) {
 		require_once $REX['INCLUDE_PATH'] .'/addons/multinewsletter/classes/class.multinewsletter_user.inc.php';
 
 		$user = MultinewsletterUser::initByMail($unsubscribe_mail, $REX['TABLE_PREFIX']);


### PR DESCRIPTION
Wenn man die Standard-Module Anmeldung und Abmeldung auf einer Seite verwendet, meldet er dich an und direkt wieder ab. Als Verbesserungsmaßnahme des Addons wäre es gut vorher zu prüfen, welchen Button der User gedrückt hat. Nur, wenn er den Abmelden Button gedrückt haben, wird er abgemeldet.

Wenn sich einer vom Newsletter abmelden möchte, wird geprüft, ob auch der Button abmelden geklickt wurde.